### PR TITLE
Add docs for prompt injection prompts

### DIFF
--- a/docs/prompt-library/prompt-library.md
+++ b/docs/prompt-library/prompt-library.md
@@ -2,15 +2,18 @@ This page contains a collection of prompts that you can use as is or design your
 
 <h3>Using the Prompts</h3>
 
-Users can view and utilize the full prompts by visiting the GitHub repository or cloning it locally. The prompts are available in the `prompts.ts` file within the repository.
+Users can view and utilize the full prompts by visiting the GitHub repository or cloning it locally. The prompts are available in the `prompt-library` folder within the repository.
 
 To access the prompts:
 
-1. Visit the GitHub repository: [Link to GitHub repository](https://github.com/awslabs/agents-for-amazon-bedrock-blueprints){:target="_blank"}
+1. Visit the GitHub repository: <a href="https://github.com/aws-samples/amazon-bedrock-samples/tree/main/agents-for-bedrock/agent-blueprint-templates/lib/prompt_library" target="_blank">Link to GitHub repository</a>
 2. Navigate to the prompt that you are interested in.
 3. Copy the desired prompt or clone the repository to your local machine.
 
 <h3>Prompt Summaries</h3>
+Feel free to explore and utilize these prompts in your projects or modify them according to your requirements.
+
+<h4> prompts.ts </h4>
 
 1. <h4>customPreprocessingPrompt</h4>
 This prompt is used to categorize user inputs into different categories based on their nature and intent. It helps filter out malicious or harmful inputs, inputs trying to manipulate the agent's behavior, inputs that the agent cannot answer, inputs that can be answered by the agent, inputs that are answers to the agent's questions, and inputs with multiple questions.
@@ -24,4 +27,15 @@ This prompt is used by the agent to generate an answer based on the provided sea
 4. <h4>customPostProcessingPrompt</h4>
 This prompt is used to provide additional context to the agent's response, making it more understandable for the user. It helps explain the actions taken by the agent without revealing implementation details or function names.
 
-Feel free to explore and utilize these prompts in your projects or modify them according to your requirements.
+<h4> prompt-injection-mitigation-prompts.ts </h4>
+
+These prompts add additional instructions that can help mitigate prompt injection attacks. For more information, see: <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-injection.html" target="_blank">Prompt injection security</a>
+
+1. <h4>claude3SonnetPromptInjectionOrchestrationPrompt</h4>
+This prompt is for mitigating prompt injection attacks on the Claude 3 Sonnet model.
+
+2. <h4>claude3HaikuPromptInjectionOrchestrationPrompt</h4>
+This prompt is for mitigating prompt injection attacks on the Claude 3 Haiku model.
+
+3. <h4>titanTextPremierPromptInjectionOrchestrationPrompt</h4>
+This prompt is for mitigating prompt injection attacks on the Amazon Titan Text G1 - Premier model.

--- a/docs/prompt-library/prompt-library.md
+++ b/docs/prompt-library/prompt-library.md
@@ -6,12 +6,62 @@ Users can view and utilize the full prompts by visiting the GitHub repository or
 
 To access the prompts:
 
-1. Visit the GitHub repository: <a href="https://github.com/aws-samples/amazon-bedrock-samples/tree/main/agents-for-bedrock/agent-blueprint-templates/lib/prompt_library" target="_blank">Link to GitHub repository</a>
+1. Visit the GitHub repository: [Link to GitHub repository](https://github.com/aws-samples/amazon-bedrock-samples/tree/main/agents-for-bedrock/agent-blueprint-templates/lib/prompt_library){:target="_blank"}
 2. Navigate to the prompt that you are interested in.
 3. Copy the desired prompt or clone the repository to your local machine.
 
 <h3>Prompt Summaries</h3>
 Feel free to explore and utilize these prompts in your projects or modify them according to your requirements.
+
+<details>
+<summary>Example Code Snippet Using a Prompt</summary>
+
+```ts
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { AgentDefinitionBuilder, PromptType } from '../../agents-for-amazon-bedrock-blueprints/lib/constructs/AgentDefinitionBuilder';
+import { BedrockAgentBlueprintsConstruct } from '../../agents-for-amazon-bedrock-blueprints/lib/constructs/BedrockAgentBlueprintsConstruct';
+import * as bedrock from 'aws-cdk-lib/aws-bedrock';
+
+import {
+    claude3SonnetPromptInjectionOrchestrationPrompt
+} from '../../amazon-bedrock-samples/agents-for-bedrock/agent-blueprint-templates/lib/prompt_library/prompt-injection-mitigation-prompts'
+
+
+export class MyCdkAppStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const prompt: bedrock.CfnAgent.PromptConfigurationProperty = {
+      promptType: PromptType.ORCHESTRATION,
+      promptCreationMode: "OVERRIDDEN",
+      inferenceConfiguration: {
+        maximumLength: 2048,
+        stopSequences: ["\n\nHuman:"],
+        temperature: 0,
+        topK: 250,
+        topP: 1,
+      },
+      basePromptTemplate: claude3SonnetPromptInjectionOrchestrationPrompt,
+    };
+
+    const agentDef = new AgentDefinitionBuilder(this, 'NewAgentDef', {})
+        .withAgentName('NewFriendlyAgent')
+        .withInstruction('nice new fun agent to do great things in code')
+        .withUserInput()
+        .withOrchestrationPrompt(prompt)
+        .withFoundationModel('anthropic.claude-3-sonnet-20240229-v1:0')
+        .build();
+
+
+    new BedrockAgentBlueprintsConstruct(this, 'AmazonBedrockAgentBlueprintsStack', {
+      agentDefinition: agentDef,
+    });
+  }
+}
+```
+
+</details>
 
 <h4> prompts.ts </h4>
 
@@ -29,7 +79,7 @@ This prompt is used to provide additional context to the agent's response, makin
 
 <h4> prompt-injection-mitigation-prompts.ts </h4>
 
-These prompts add additional instructions that can help mitigate prompt injection attacks. For more information, see: <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-injection.html" target="_blank">Prompt injection security</a>
+These prompts add additional instructions that can help mitigate prompt injection attacks. For more information, see: [Prompt injection security](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-injection.html){:target="_blank"}
 
 1. <h4>claude3SonnetPromptInjectionOrchestrationPrompt</h4>
 This prompt is for mitigating prompt injection attacks on the Claude 3 Sonnet model.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds documentation for the new prompt injection mitigation prompts inside of a new prompts file. Also cleans up an incorrect link and does some reorganizing/rewording of the docs to account for the new file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
