### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 env:
   envInfo: "CI/CD workflow"
 
+permissions:
+  contents: read
+
 jobs:
   git-secrets:
     runs-on: ubuntu-latest

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+permissions:
+  contents: write
+
 jobs:
     publish:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.